### PR TITLE
v2.0.0 mkcert on ubuntu (and my script on MacOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Serve static files or import as module in your project.
 [![GitHub issues](https://img.shields.io/github/issues/daquinoaldo/https-localhost.svg)](https://github.com/daquinoaldo/https-localhost/issues)
 [![npm version](https://img.shields.io/npm/v/https-localhost.svg)](https://www.npmjs.com/package/https-localhost?activeTab=versions)
 
+### Install
+```
+npm install -g --unsafe-perm=true https-localhost
+```
+#### Why `unsafe-perm=true`?
+Is needed on Ubuntu to correctly run the post-install script that trust the localhost SSl certificate.  
+You can skip it on other platforms.
+
+If you don't trust the script, you can install it in the usual way and than follow the [optional instructions](#optional--trust-the-certificate).
 
 ### Use standalone
 From terminal navigate into the folder and run `sudo npm install -g` to install this tool globally.
@@ -40,7 +49,7 @@ To redirect the http traffic to https use `app.redirect()`.
 You can also serve static files with `app.serve(path)`
 
 
-### [Optional] Install and trust the certificate
+### [Optional] Trust the certificate
 **If you are not on MacOS or Ubuntu, you should follow this instructions.**
 
 After `npm install` will run a script that tries to install and validate automatically the certificate.

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ To redirect the http traffic to https use `app.redirect()`.
 You can also serve static files with `app.serve(path)`
 
 
-### [Optional/Linux] Install and trust the certificate
-After `npm install` will run a script that tries to install and validate automatically the certificate.
-**Actually works only on MacOS.**
+### [Optional] Install and trust the certificate
+**If you are not on MacOS or Ubuntu, you should follow this instructions.**
 
-However, this script is in beta and provided as-is, so there isn't any guarantee that will work.  
+After `npm install` will run a script that tries to install and validate automatically the certificate.
+However, this script is in beta and provided as-is, so there isn't any guarantee that will work.
 For that reason you can also install the certificate manually, as follows.
 
 If you decide to not install it, it's fine, the package still work.
@@ -60,6 +60,15 @@ menu and select the file. Then double-click on the certificate and select always
 - Linux:
     Depending on your Linux distribution, you can use `trust`, `update-ca-certificates`
 or another command to mark the generated root certificate as trusted.
+
+#### TL;DR
+Looking for something easier? Take a look to [mkcert](https://github.com/FiloSottile/mkcert) (requires Go).
+
+Install it, then move into the https-localhost folder and run:
+```
+mkcert -install
+mkcert -cert-file cert/localhost.crt -key-file cert/localhost.key localhost
+```
 
 
 ### License

--- a/cert/generate.js
+++ b/cert/generate.js
@@ -1,31 +1,17 @@
 const exec = require("child_process").exec
 
 // noinspection FallThroughInSwitchStatementJS
-switch (process.platform) {
-  case "darwin": // MacOS
-  case "linux":
-    console.log("\n----------------------------------------------\n" +
-                  "Please input your sudo password when required.\n" +
-                  "----------------------------------------------\n")
-    exec("bash cert/generate.sh", (error, stdout, stderr) => {
-      console.log(stdout)
-      console.error(stderr)
-      if (error !== null) console.error(`exec error: ${error}`)
-    })
-    break
-  case "win32":
-    console.warn("Cannot generate the localhost certificate on Windows.")
-    process.exit(0)
-  case "freebsd":
-    console.warn("Cannot generate the localhost certificate on freebsd. " +
-      "Help wanted.")
-    process.exit(0)
-  case "sunos":
-    console.warn("Cannot generate the localhost certificate on sunos. " +
-      "Help wanted.")
-    process.exit(0)
-  default:
-    console.warn("Cannot generate the localhost certificate on your " +
-      "platform. Contact the developer.")
-    process.exit(0)
+if (process.platform === "darwin" || process.platform === "linux") {
+  console.log("\n----------------------------------------------\n" +
+                "Please input your sudo password if required.\n" +
+                "----------------------------------------------\n")
+  exec("bash cert/generate.sh", (error, stdout, stderr) => {
+    console.log(stdout)
+    console.error(stderr)
+    if (error !== null) console.error(`exec error: ${error}`)
+  })
+} else {
+  console.warn("Cannot generate the localhost certificate on your " +
+      "platform. Contact the developer if you can help.")
+  process.exit(0)
 }

--- a/cert/generate.js
+++ b/cert/generate.js
@@ -3,6 +3,7 @@ const exec = require("child_process").exec
 // noinspection FallThroughInSwitchStatementJS
 switch (process.platform) {
   case "darwin": // MacOS
+  case "linux":
     console.log("\n----------------------------------------------\n" +
                   "Please input your sudo password when required.\n" +
                   "----------------------------------------------\n")
@@ -12,10 +13,6 @@ switch (process.platform) {
       if (error !== null) console.error(`exec error: ${error}`)
     })
     break
-  case "linux":
-    console.warn("Cannot generate the localhost certificate on linux yet. " +
-      "Coming soon.")
-    process.exit(0)
   case "win32":
     console.warn("Cannot generate the localhost certificate on Windows.")
     process.exit(0)

--- a/cert/generate.sh
+++ b/cert/generate.sh
@@ -8,14 +8,11 @@ trap 'if [[ $? -ne 0 ]]; then echo "ERROR: something went wrong."; fi' EXIT
 case "$(uname -s)" in
     Darwin*) machine=MacOS;;
     Linux*)  machine=Linux
-        echo "Linux support coming soon"
-        exit 1;;
+        echo "WARNING: Only Ubuntu is supported. No guarantee for other Linux distributions.";;
     CYGWIN*) machine=Linux
-        echo "WARNING: Support for Cygwin not guaranteed. Trying with the Linux script (coming soon)."
-        exit 1;;
+        echo "WARNING: Support for Cygwin not guaranteed. Trying with the Linux script (coming soon).";;
     MINGW*)  machine=Linux
-        echo "WARNING: Support for MinGw not guaranteed. Trying with the Linux script (coming soon)."
-        exit 1;;
+        echo "WARNING: Support for MinGw not guaranteed. Trying with the Linux script (coming soon).";;
     *) echo "Unknown operating system."; exit 1;;
 esac
 
@@ -24,24 +21,30 @@ echo "Creating a certification authority to sign the certificate..."
 openssl req -x509 -newkey rsa:4096 -keyout cert/CA.key -out cert/CA.pem -days 1024 -nodes -subj "/C=US/ST=None/L=None/O=None/OU=None/CN=localhost"
 echo "Generated CA.key and CA.pem."
 
-# install the CA
-case ${machine} in
-    MacOS*)
-        sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain cert/CA.pem
-        ;;
-    Linux*)
-        echo "WARNING: Only Ubuntu is supported. No guarantee for other Linux distributions."
-        sudo mkdir /usr/local/share/ca-certificates/localhost
-        cp cert/CA.key /usr/local/share/ca-certificates/localhost/CA.key
-        cp cert/CA.pem /usr/local/share/ca-certificates/localhost/CA.pem
-        sudo chmod 775 /usr/local/share/ca-certificates/localhost
-        sudo update-ca-certificates
-        ;;
-    *) exit 1;;
-esac
-
 # crate the certificate
 echo "Creating a certificate for localhost and signing with out CA..."
 openssl req -new -sha256 -nodes -out cert/server.csr -newkey rsa:2048 -keyout cert/localhost.key -config cert/server.conf
 openssl x509 -req -in cert/server.csr -CAkey cert/CA.key -CA cert/CA.pem -CAcreateserial -out cert/localhost.crt -days 1024 -sha256 -extfile cert/x509.ext
 echo "Generated localhost.key and localhost.crt."
+
+# install the CA
+echo "Installing the certificate..."
+case ${machine} in
+    MacOS*)
+        sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain cert/CA.pem
+        ;;
+    Linux*)
+        echo "Using mkcert on linux."
+        sudo apt install -y golang-go libnss3-tools
+        PATH=$(go env GOPATH)/bin:$PATH
+        mkcert -install
+        mkcert -cert-file cert/localhost.crt -key-file cert/localhost.key localhost
+        #sudo cp cert/CA.pem /usr/local/share/ca-certificates/localhost.crt
+        #sudo chmod 664 /usr/local/share/ca-certificates/localhost.crt
+        #sudo update-ca-certificates
+        ;;
+    *) exit 1;;
+esac
+echo "Certificate installed."
+
+

--- a/cert/generate.sh
+++ b/cert/generate.sh
@@ -6,32 +6,22 @@ trap 'if [[ $? -ne 0 ]]; then echo "ERROR: something went wrong."; fi' EXIT
 
 # check the os
 case "$(uname -s)" in
-    Darwin*) machine=MacOS;;
-    Linux*)  machine=Linux
-        echo "WARNING: Only Ubuntu is supported. No guarantee for other Linux distributions.";;
-    CYGWIN*) machine=Linux
-        echo "WARNING: Support for Cygwin not guaranteed. Trying with the Linux script (coming soon).";;
-    MINGW*)  machine=Linux
-        echo "WARNING: Support for MinGw not guaranteed. Trying with the Linux script (coming soon).";;
-    *) echo "Unknown operating system."; exit 1;;
-esac
+    Darwin*)
+        # generate the CA
+        echo "Creating a certification authority to sign the certificate..."
+        openssl req -x509 -newkey rsa:4096 -keyout cert/CA.key -out cert/CA.pem -days 1024 -nodes -subj "/C=US/ST=None/L=None/O=None/OU=None/CN=localhost"
+        echo "Generated CA.key and CA.pem."
 
-# generate the CA
-echo "Creating a certification authority to sign the certificate..."
-openssl req -x509 -newkey rsa:4096 -keyout cert/CA.key -out cert/CA.pem -days 1024 -nodes -subj "/C=US/ST=None/L=None/O=None/OU=None/CN=localhost"
-echo "Generated CA.key and CA.pem."
+        # crate the certificate
+        echo "Creating a certificate for localhost and signing with out CA..."
+        openssl req -new -sha256 -nodes -out cert/server.csr -newkey rsa:2048 -keyout cert/localhost.key -config cert/server.conf
+        openssl x509 -req -in cert/server.csr -CAkey cert/CA.key -CA cert/CA.pem -CAcreateserial -out cert/localhost.crt -days 1024 -sha256 -extfile cert/x509.ext
+        echo "Generated localhost.key and localhost.crt."
 
-# crate the certificate
-echo "Creating a certificate for localhost and signing with out CA..."
-openssl req -new -sha256 -nodes -out cert/server.csr -newkey rsa:2048 -keyout cert/localhost.key -config cert/server.conf
-openssl x509 -req -in cert/server.csr -CAkey cert/CA.key -CA cert/CA.pem -CAcreateserial -out cert/localhost.crt -days 1024 -sha256 -extfile cert/x509.ext
-echo "Generated localhost.key and localhost.crt."
-
-# install the CA
-echo "Installing the certificate..."
-case ${machine} in
-    MacOS*)
+        # install the CA
+        echo "Installing the certificate..."
         sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain cert/CA.pem
+        echo "Certificate installed."
         ;;
     Linux*)
         echo "Using mkcert on linux."
@@ -43,8 +33,8 @@ case ${machine} in
         #sudo chmod 664 /usr/local/share/ca-certificates/localhost.crt
         #sudo update-ca-certificates
         ;;
-    *) exit 1;;
+    *)
+        echo "Unsupported system."
+        exit 1
+        ;;
 esac
-echo "Certificate installed."
-
-

--- a/cert/generate.sh
+++ b/cert/generate.sh
@@ -26,12 +26,10 @@ case "$(uname -s)" in
     Linux*)
         echo "Using mkcert on linux."
         sudo apt install -y golang-go libnss3-tools
+        go get -u github.com/FiloSottile/mkcert
         PATH=$(go env GOPATH)/bin:$PATH
         mkcert -install
         mkcert -cert-file cert/localhost.crt -key-file cert/localhost.key localhost
-        #sudo cp cert/CA.pem /usr/local/share/ca-certificates/localhost.crt
-        #sudo chmod 664 /usr/local/share/ca-certificates/localhost.crt
-        #sudo update-ca-certificates
         ;;
     *)
         echo "Unsupported system."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "https-localhost",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "HTTPS server running on localhost",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# PR Details
Automatically run a postinstall script that trust the generated certificate on MacOS and Ubuntu.

## Description
The script uses openssl on MacOS and adds the CA certificate to the Mac trust store.
On Ubuntu uses the [mkcert](https://github.com/FiloSottile/mkcert) tool.

## Motivation and Context
It really helps in automating the process for users. Now in the two most popular OS there is no need for an additional user interaction.

## How Has This Been Tested
It is not tested automatically, but has been tested on Ubuntu 18.04 LTS and MacOS Mojave.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] ~~I have added tests to cover my changes.~~ Is too expensive to test it automatically.
- [x] All new and existing tests passed.
