### PR TITLE
#16 workaround

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,9 +40,13 @@ const createServer = () => {
     /* istanbul ignore next: cannot be tested on Travis */ httpPort = 80,
     httpsPort = process.env.PORT || 443) {
     app.http = http.createServer((req, res) => {
+      const reqHost = req.headers["host"]
+        ? req.headers["host"].replace(":" + httpPort, "")
+        : /* istanbul ignore next: cannot be tested */ "localhost"
       res.writeHead(301, {
-        Location: "https://" + req.headers["host"].replace(":" + httpPort, "") +
-          (httpsPort !== 443 ? ":" + httpsPort : "") + req.url
+        Location: "https://" + reqHost +
+          (httpsPort !== 443 ? ":" + httpsPort : "") + (req.url ||
+        /* istanbul ignore next: cannot be tested */ "")
       })
       res.end()
     }).listen(httpPort)


### PR DESCRIPTION
# Pull Request Details
Fix an error that can occur due to an undefined value of `req.headers["host"]` on express.js.
Since a fix is not possible, we provided a workaround that fixes the bug on localhost. This script should run only on localhost as developing support, hence this workaround shouldn't cause problems (and in any case prevent a brutal crash).

## Related Issue
#16 

## Types of changes
<!-- Put an `x` in all the boxes that apply -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)