### PR TITLE
Generate certificate for other domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ app.listen(port)
 - If the **port** number is not provided, it will listen on 443.
 - To **redirect** the http traffic to https use `app.redirect()`.
 - You can serve **static files** with `app.serve(path)`.
+- You can create create a certificate for additional domains with `require("https-localhost")("mydomain.com")`
 
 **Tip:** consider installing it as a dev dependency: this is not a production tool!  
 `npm i --save-dev https-localhost`

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ app.listen(port)
 - If the **port** number is not provided, it will listen on 443.
 - To **redirect** the http traffic to https use `app.redirect()`.
 - You can serve **static files** with `app.serve(path)`.
-- You can create create a certificate for additional domains with `require("https-localhost")("mydomain.com")`
+- You can create a certificate for additional domains with `require("https-localhost")("mydomain.com")`
 
 **Tip:** consider installing it as a dev dependency: this is not a production tool!  
 `npm i --save-dev https-localhost`

--- a/certs.js
+++ b/certs.js
@@ -69,17 +69,16 @@ function download(url, path) {
 }
 
 // execute the binary executable to generate the certificates
-function mkcert(appDataPath, exe, customDomain) {
+function mkcert(appDataPath, exe, domain) {
   const logPath = path.join(appDataPath, "mkcert.log")
   const errPath = path.join(appDataPath, "mkcert.err")
   // escape spaces in appDataPath (Mac OS)
   appDataPath = appDataPath.replace(" ", "\\ ")
   const exePath = path.join(appDataPath, exe)
-  const crtPath = path.join(appDataPath, "localhost.crt")
-  const keyPath = path.join(appDataPath, "localhost.key")
+  const crtPath = path.join(appDataPath, domain + ".crt")
+  const keyPath = path.join(appDataPath, domain + ".key")
   const cmd = exePath + " -install -cert-file " + crtPath +
-    " -key-file " + keyPath + " localhost " + customDomain
-  console.log(cmd)
+    " -key-file " + keyPath + " " + domain
   return new Promise((resolve, reject) => {
     console.log("Running mkcert to generate certificates...")
     exec(cmd, (err, stdout, stderr) => {
@@ -97,7 +96,8 @@ function mkcert(appDataPath, exe, customDomain) {
   })
 }
 
-async function generate(appDataPath = CERT_PATH, customDomain = "") {
+async function generate(appDataPath = CERT_PATH, customDomain = undefined) {
+  const domain = customDomain || "localhost"
   console.info("Generating certificates...")
   console.log("Certificates path: " + appDataPath +
     ". Never modify nor share this files.")
@@ -115,7 +115,7 @@ async function generate(appDataPath = CERT_PATH, customDomain = "") {
   // make binary executable
   fs.chmodSync(exePath, "0755")
   // execute the binary
-  await mkcert(appDataPath, exe, customDomain)
+  await mkcert(appDataPath, exe, domain)
   console.log("Certificates generated, installed and trusted. Ready to go!")
 }
 
@@ -144,7 +144,7 @@ async function getCerts(customDomain) {
       // generate the certificate
       await generate(CERT_PATH, customDomain)
       // recursive call
-      return getCerts()
+      return getCerts(customDomain)
     }
   }
 }

--- a/certs.js
+++ b/certs.js
@@ -119,7 +119,8 @@ async function generate(appDataPath = CERT_PATH, customDomain = undefined) {
   console.log("Certificates generated, installed and trusted. Ready to go!")
 }
 
-async function getCerts(customDomain) {
+async function getCerts(customDomain = undefined) {
+  const domain = customDomain || "localhost"
   const certPath = process.env.CERT_PATH || CERT_PATH
   // check for updates if running as executable
   /* istanbul ignore if: cannot test pkg */
@@ -127,11 +128,11 @@ async function getCerts(customDomain) {
   // check if a reinstall is forced or needed by a mkcert update
   if (process.env.REINSTALL ||
       !fs.existsSync(path.join(certPath, getExe())))
-    await generate(certPath, customDomain)
+    await generate(certPath, domain)
   try {
     return {
-      key: fs.readFileSync(path.join(certPath, "localhost.key")),
-      cert: fs.readFileSync(path.join(certPath, "localhost.crt"))
+      key: fs.readFileSync(path.join(certPath, domain + ".key")),
+      cert: fs.readFileSync(path.join(certPath, domain + ".crt"))
     }
   } catch (e) {
     /* istanbul ignore else: should never occur */
@@ -142,9 +143,9 @@ async function getCerts(customDomain) {
     } else {
       // Missing certificates (first run)
       // generate the certificate
-      await generate(CERT_PATH, customDomain)
+      await generate(CERT_PATH, domain)
       // recursive call
-      return getCerts(customDomain)
+      return getCerts(domain)
     }
   }
 }

--- a/certs.js
+++ b/certs.js
@@ -97,7 +97,7 @@ function mkcert(appDataPath, exe, customDomain) {
   })
 }
 
-async function generate(appDataPath, customDomain = "") {
+async function generate(appDataPath = CERT_PATH, customDomain = "") {
   console.info("Generating certificates...")
   console.log("Certificates path: " + appDataPath +
     ". Never modify nor share this files.")
@@ -167,7 +167,7 @@ if (require.main === module)
     remove()
     console.info("Certificates removed.")
   } else try { // install
-    generate(CERT_PATH)
+    generate()
   } catch (err) { console.error("\nExec error: " + err) }
 
 // export as module

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const getCerts = require(path.resolve(__dirname, "certs.js")).getCerts
 /* CONFIGURE THE SERVER */
 
 // SSL certificate
-const createServer = (customDomain = "") => {
+const createServer = (domain = "localhost") => {
   // create a server with express
   const app = express()
 
@@ -22,7 +22,7 @@ const createServer = (customDomain = "") => {
   // override the default express listen method to use our server
   app.listen = async function(port = process.env.PORT ||
   /* istanbul ignore next: cannot be tested on Travis */ 443) {
-    app.server = https.createServer(await getCerts(customDomain), app)
+    app.server = https.createServer(await getCerts(domain), app)
       .listen(port)
     console.info("Server running on port " + port + ".")
     return app.server

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ const createServer = (customDomain = "") => {
   // override the default express listen method to use our server
   app.listen = async function(port = process.env.PORT ||
   /* istanbul ignore next: cannot be tested on Travis */ 443) {
-    app.server = https.createServer(await getCerts(customDomain), app).listen(port)
+    app.server = https.createServer(await getCerts(customDomain), app)
+      .listen(port)
     console.info("Server running on port " + port + ".")
     return app.server
   }

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const getCerts = require(path.resolve(__dirname, "certs.js")).getCerts
 /* CONFIGURE THE SERVER */
 
 // SSL certificate
-const createServer = () => {
+const createServer = (customDomain = "") => {
   // create a server with express
   const app = express()
 
@@ -22,7 +22,7 @@ const createServer = () => {
   // override the default express listen method to use our server
   app.listen = async function(port = process.env.PORT ||
   /* istanbul ignore next: cannot be tested on Travis */ 443) {
-    app.server = https.createServer(await getCerts(), app).listen(port)
+    app.server = https.createServer(await getCerts(customDomain), app).listen(port)
     console.info("Server running on port " + port + ".")
     return app.server
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "https-localhost",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1320,13 +1320,21 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.1.tgz",
-      "integrity": "sha512-5fa/gR2yR3NxQf+UXkeLeP8FBBl6tSgdrAz1+cF84v1FMM4twGwQoqTnn+QxFLcPOrF4pdKEJKDB/q9GoyJrCA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-2.0.0.tgz",
+      "integrity": "sha512-f6fceVtg27BR02EYnBhgWLFQfK6bN4Ll0nQFrBHOlCsAyxeZkn0NHns5O0YZOPrV1B3ramd6cgFwaoFLcSkwEQ==",
       "dev": true,
       "requires": {
         "eslint-utils": "^1.4.2",
-        "regexpp": "^2.0.1"
+        "regexpp": "^3.0.0"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-import": {
@@ -1361,12 +1369,12 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-9.2.0.tgz",
-      "integrity": "sha512-2abNmzAH/JpxI4gEOwd6K8wZIodK3BmHbTxz4s79OIYwwIt2gkpEXlAouJXu4H1c9ySTnRso0tsuthSOZbUMlA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-10.0.0.tgz",
+      "integrity": "sha512-1CSyM/QCjs6PXaT18+zuAXsjXGIGo5Rw630rSKwokSs2jrYURQc4R5JZpoanNCqwNmepg+0eZ9L7YiRUJb8jiQ==",
       "dev": true,
       "requires": {
-        "eslint-plugin-es": "^1.4.1",
+        "eslint-plugin-es": "^2.0.0",
         "eslint-utils": "^1.4.2",
         "ignore": "^5.1.1",
         "minimatch": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "https-localhost",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "HTTPS server running on localhost",
   "main": "index.js",
   "scripts": {
@@ -55,7 +55,7 @@
     "eslint": "^6.3.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-node": "^9.2.0",
+    "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "mocha": "^6.2.0",


### PR DESCRIPTION
<!-- PREMISE: I would really appreciate if you could follow this scheme as much as possible. -->
<!-- Anyway, I believe in open source software and I really appreciate those who decide to work on a project that appreciates. -->
<!-- If this scheme puts you in trouble, feel free to follow it only partially or not to follow it at all. -->
<!-- Your contribution will be taken to heart and welcomed with open arms in the same way, it will only need a little more work to integrate the changes. -->

# Pull Request Details

## Related Issue
Please, open an issue before a pull request. It will help in understanding better the PR aim.

## Types of changes
<!-- Put an `x` in all the boxes that apply -->
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation or my changes dont require it.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes (or the existing one were enough).
- [x] All new and existing tests passed.

First, thank you so much for this project, it's a huge win in terms of making it easy to use https for development. 

We would like to use this on a custom domain that we use for dev. It's a pretty simple change to generate the certificate for additional domains, but I'm not super happy with how I've passed the new option down to `mkcert`. Any suggestions for how to improve this?

Very open to writing any tests or documentation that you request. 
