### PR TITLE
Pass through hostname and callback parameters in app.listen

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,9 +26,9 @@ const createServer = (domain = process.env.HOST || "localhost") => {
 
   // override the default express listen method to use our server
   app.listen = async function(port = process.env.PORT ||
-  /* istanbul ignore next: cannot be tested on Travis */ 443) {
+  /* istanbul ignore next: cannot be tested on Travis */ 443, hostname, callback) {
     app.server = https.createServer(await getCerts(domain), app)
-      .listen(port)
+      .listen(port, hostname, callback)
     console.info("Server running on port " + port + ".")
     return app.server
   }


### PR DESCRIPTION
<!-- PREMISE: I would really appreciate if you could follow this scheme as much as possible. -->
<!-- Anyway, I believe in open source software and I really appreciate those who decide to work on a project that appreciates. -->
<!-- If this scheme puts you in trouble, feel free to follow it only partially or not to follow it at all. -->
<!-- Your contribution will be taken to heart and welcomed with open arms in the same way, it will only need a little more work to integrate the changes. -->

# Pull Request Details
I did a swap straight from a non-https version of connect to this module and wasn't able to use an `app.listen` callback anymore, because the module ignores the `hostname` and `callback` parameters. Changed it locally since I only need this locally, but I figured it should probably be updated here for anyone else that runs into this.

## Related Issue
> Please, open an issue before a pull request. It will help in understanding better the PR aim.

It adds two (2) params and I explained it above. If you'd like to close or whatever that's fine, I don't mind

## Types of changes
<!-- Put an `x` in all the boxes that apply -->
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation or my changes dont require it.
- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.  <————————— I dunno if I'm dumb but I can't find it.
- [x] I have added tests to cover my changes (or the existing one were enough).
- [ ] All new and existing tests passed.   <—————————— Dunno how to run it, I assume that would've been covered in the document I can't find
