### PR TITLE
Avoid installing a global uncaughtException handler on import

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,27 +95,27 @@ if (require.main === module) {
   app.serve(process.argv.length === 3 ? process.argv[2] : process.cwd())
   // redirect http to https (only if https port is the default one)
   if (!process.env.PORT) app.redirect()
-}
 
-/* istanbul ignore next: cannot be tested */
-process.on("uncaughtException", function(err) {
-  switch (err.errno) {
-    case "EACCES":
-      console.error(
-        "EACCES: run as administrator to use the default ports 443 and 80. " +
-        "You can also change port with: `PORT=4433 serve ~/myproj`.")
-      break
-    case "EADDRINUSE":
-      console.error("EADDRINUSE: another service on your machine is using " +
-      "the current port.\nStop it or change port with:" +
-      "`PORT=4433 serve ~/myproj`.")
-      break
-    default:
-      console.error("Unexpected error " + err.errno + ":\n\n" + err)
-      break
-  }
-  process.exit(1)
-})
+  /* istanbul ignore next: cannot be tested */
+  process.on("uncaughtException", function(err) {
+    switch (err.errno) {
+      case "EACCES":
+        console.error(
+          "EACCES: run as administrator to use the default ports 443 and 80. " +
+          "You can also change port with: `PORT=4433 serve ~/myproj`.")
+        break
+      case "EADDRINUSE":
+        console.error("EADDRINUSE: another service on your machine is using " +
+        "the current port.\nStop it or change port with:" +
+        "`PORT=4433 serve ~/myproj`.")
+        break
+      default:
+        console.error("Unexpected error " + err.errno + ":\n\n" + err)
+        break
+    }
+    process.exit(1)
+  })
+}
 
 // export as module
 module.exports = createServer

--- a/test/import.js
+++ b/test/import.js
@@ -1,0 +1,16 @@
+const assert = require("assert")
+
+describe("Testing module import", () => {
+  it("doesn't install an uncaughtException handler when imported", () => {
+    const modulePath = require.resolve("../index.js")
+    const listenersBefore = process.listenerCount("uncaughtException")
+
+    delete require.cache[modulePath]
+    require(modulePath)
+
+    assert.strictEqual(
+      process.listenerCount("uncaughtException"),
+      listenersBefore
+    )
+  })
+})


### PR DESCRIPTION
# Pull Request Details

## Related Issue
Addresses #77.

Importing `https-localhost` currently installs a process-wide `uncaughtException` handler even when the package is only used as a module. That changes application-level error handling and can hide the original stack-trace behavior.

This change scopes the existing handler to the CLI path (`require.main === module`) so the CLI keeps its friendly `EACCES` / `EADDRINUSE` messages while library consumers no longer get a global process listener as a side effect of `require("https-localhost")`.

A regression test re-imports the module after clearing the require cache and verifies that the `uncaughtException` listener count does not change.

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project.
- [x] I have updated the documentation or my changes dont require it.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.