### PR TITLE
ci: use Node 24 and add 'existing' option to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
           package-manager-cache: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       upgrade:
-        description: Type of version upgrade (patch, minor, major)
+        description: Version action (patch, minor, major, or publish existing without bumping)
         required: true
         default: patch
         type: choice
@@ -12,11 +12,7 @@ on:
           - patch
           - minor
           - major
-      publish_existing:
-        description: Publish the version already on master without changing it
-        required: true
-        default: false
-        type: boolean
+          - existing
 
 permissions:
   contents: write
@@ -34,17 +30,17 @@ jobs:
           package-manager-cache: false
 
       - name: Setup git
-        if: inputs.publish_existing == false
+        if: inputs.upgrade != 'existing'
         run: |-
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Bump version
-        if: inputs.publish_existing == false
+        if: inputs.upgrade != 'existing'
         run: npm version ${{ inputs.upgrade }}
 
       - name: Push version
-        if: inputs.publish_existing == false
+        if: inputs.upgrade != 'existing'
         run: |-
           git push
           git push --tags


### PR DESCRIPTION
Bump release runner to Node 24 for npm Trusted Publishing OIDC support, and consolidate the release action into a single `upgrade` input with options: `patch`, `minor`, `major`, and `existing` (publish without re-bumping).

🤖 Generated with [OpenCode](https://opencode.ai) (Smart-router)